### PR TITLE
Update building-ubuntu.md with correct commands

### DIFF
--- a/doc/building-ubuntu.md
+++ b/doc/building-ubuntu.md
@@ -12,3 +12,22 @@ To compile Seastar explicitly using gcc 5, use:
 CXX=g++-5 ./cooking.sh -i c-ares -i fmt -t Release
 ninja -C build
 ```
+
+
+### Building seastar on Ubuntu 18.04
+
+Installing required packages:
+```
+sudo apt update
+sudo apt install git build-essential libtool m4 automake gcc-8 g++-8
+git clone --recursive https://github.com/scylladb/seastar.git
+cd seastar
+sudo ./install-dependencies.sh
+```
+
+To compile Seastar (with DPDK, explicitly using gcc 8), use:
+```
+./configure.py --mode=dev --cook fmt
+CXX=g++-8 ./cooking.sh -- -DSeastar_DPDK=ON
+CXX=g++-8 ninja -j4 -C build
+```


### PR DESCRIPTION
Corrected commands for Ubuntu 18.04
I have been unsuccessful in compiling Seastar using the builtin gcc/g++7 on Ubuntu 18.04.
Specifying GCC8 fixes compile errors and allows for building.

Having developed with seastar for a few years, I know how to setup my dev environments, but as a first-time developer it can be confusing navigating the build documentation. I think it would be really helpful for devs who are new to seastar to know exactly what to do to easily get up and running.